### PR TITLE
Fix version format for development build

### DIFF
--- a/get/CHANGELOG.md
+++ b/get/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.1
+
+- Fix version format for development build
+
 # 1.1.0
 
 - Added option to get development builds

--- a/get/rootfs/etc/addon/run
+++ b/get/rootfs/etc/addon/run
@@ -30,7 +30,7 @@ elif bashio::var.equals "${CHANNEL}" "development"; then
 
     bashio::log.info "Injecting a version..."
     current_version=$(curl -sSL https://data-v2.hacs.xyz/integration/data.json | jq -r '.["172733314"].last_version')
-    updated_version="$(echo "${current_version}" | awk -F. -v OFS=. '{$NF += 1 ; print}').dev$(git rev-parse --short HEAD)"
+    updated_version="$(echo "${current_version}" | awk -F. -v OFS=. '{$NF += 1 ; print}')-dev-$(git rev-parse --short HEAD)"
     python3 ./scripts/update/manifest.py --version "${updated_version}"
     bashio::log.info "Version set to: ${updated_version}"
 


### PR DESCRIPTION
Home Assistant does not allow custom integrations to have version numbers like `1.34.1.devb4fe3fe` 🙈 