### PR TITLE
Set dev version to 2.0.0

### DIFF
--- a/get/CHANGELOG.md
+++ b/get/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.0
+
+- Set dev version to 2.0.0
+
 # 1.1.1
 
 - Fix version format for development build

--- a/get/config.yaml
+++ b/get/config.yaml
@@ -1,5 +1,5 @@
 name: Get HACS
-version: "1.1.1"
+version: "1.2.0"
 slug: get
 image: "ghcr.io/hacs/{arch}-addon-get"
 description: The easiest way to get HACS for Home Assistant

--- a/get/rootfs/etc/addon/run
+++ b/get/rootfs/etc/addon/run
@@ -29,8 +29,7 @@ elif bashio::var.equals "${CHANNEL}" "development"; then
     bash ./scripts/install/frontend
 
     bashio::log.info "Injecting a version..."
-    current_version=$(curl -sSL https://data-v2.hacs.xyz/integration/data.json | jq -r '.["172733314"].last_version')
-    updated_version="$(echo "${current_version}" | awk -F. -v OFS=. '{$NF += 1 ; print}')-dev-$(git rev-parse --short HEAD)"
+    updated_version="2.0.0-dev-$(git rev-parse --short HEAD)"
     python3 ./scripts/update/manifest.py --version "${updated_version}"
     bashio::log.info "Version set to: ${updated_version}"
 


### PR DESCRIPTION
This should be reverted after 2.0.0 drops, but for now this make sense.