### PR TITLE
Change boot option to manual_only

### DIFF
--- a/get/config.yaml
+++ b/get/config.yaml
@@ -4,7 +4,7 @@ slug: get
 image: "ghcr.io/hacs/{arch}-addon-get"
 description: The easiest way to get HACS for Home Assistant
 startup: once
-boot: manual
+boot: manual_only
 url: "https://github.com/hacs/addons/tree/main/get"
 arch:
   - armhf


### PR DESCRIPTION
Add-on should never start at boot, prevents users from changing it. https://github.com/home-assistant/supervisor/pull/5272