### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels:
+      - "pr: dependency-update"
+    schedule:
+      interval: daily
+      time: "06:00"
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,18 @@
 version: 2
 updates:
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    labels:
+      - "pr: dependency-update"
+    schedule:
+      interval: weekly
+      time: "06:00"
+    open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     labels:
       - "pr: dependency-update"
     schedule:
-      interval: daily
+      interval: weekly
       time: "06:00"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Frenck's add-on linter has been updated to support #11 but there is no PR for the new release opened.
I noticed this repo (unlike others in this project) does not have dependabot enabled to update github actions.