### PR TITLE
Clarify HACS setup after installing the app

### DIFF
--- a/get/README.md
+++ b/get/README.md
@@ -9,6 +9,9 @@ The easiest way to get HACS for Home Assistant.
 1. Use the **Install** button above to build the app.
 2. Start the app.
 3. Navigate to the app logs and follow the instructions given there.
+4. After following the instructions go to Settings->Devices & Services
+5. Click the button "+ Add Integration" and search for HACS
+6. Follow the instructions
 
 > [!NOTE]
 > When you see the line "Remember to restart Home Assistant before you configure it" in the logs,


### PR DESCRIPTION
What does this PR do?

Clarifies the installation process by explicitly explaining what to do after the app installation instructions have been completed.

The additional steps direct the user to:

Restart/configure Home Assistant as required by the app instructions.
Go to Settings → Devices & services.
Select + Add integration.
Search for HACS.
Complete the HACS setup.
Why?

When following the installation process, it wasn't immediately clear that installing/running the app is followed by a separate step to add the HACS integration through Home Assistant.

Adding these instructions makes the complete installation path clearer for new users.